### PR TITLE
Update manual-installation.md

### DIFF
--- a/manual-installation.md
+++ b/manual-installation.md
@@ -5,7 +5,7 @@
 Install the Laravel Splade package using composer:
 
 ```bash
-composer install protonemedia/laravel-splade
+composer require protonemedia/laravel-splade
 ```
 
 Add the Route Middleware to the `Http/Kernel.php` file:


### PR DESCRIPTION
Fix manual installation via composer.

Error:

Invalid argument protonemedia/laravel-splade. Use "composer require protonemedia/laravel-splade" instead to add packages to your composer.json.
