### PR TITLE
Remove unnecessary installation part

### DIFF
--- a/automatic-installation.md
+++ b/automatic-installation.md
@@ -10,8 +10,4 @@ cd example-app
 composer require protonemedia/laravel-splade
 
 php artisan splade:install
-
-npm install
-
-npm run dev
 ```


### PR DESCRIPTION
Since [this PR is merged](https://github.com/protonemedia/laravel-splade/pull/144), we can now skip running `npm install` and `npm run dev` for installation😃