### PR TITLE
Update table-query-builder.md - splade-cell actions

### DIFF
--- a/table-query-builder.md
+++ b/table-query-builder.md
@@ -152,7 +152,7 @@ When using auto-fill, you may want to transform the presented data for a specifi
 
 ```blade
 <x-splade-table :for="$users">
-    <x-splade-cell actions>
+    <x-splade-cell action>
         <Link href="/users/{{ $item->id }}/edit"> Edit </Link>
     </x-splade-cell>
 </x-splade-table>


### PR DESCRIPTION
Documentation Section: Table Component
Topic: Built-in Query Builder
Heading: Customer column cells

"actions" attribute for the splade-cell does not work. When "actions" is used the cell does not render/ or show.  But using "action" singular works perfectly.